### PR TITLE
Static lookup support & restructuring

### DIFF
--- a/SRV.md
+++ b/SRV.md
@@ -21,22 +21,37 @@ Download the [script](https://raw.githubusercontent.com/ehloonion/onionmx/master
 Install the needed dependency:
 
     # apt install python-dnspython
+    # apt install python-yaml
+If working with virtualenvs, `pip install -r <project_path>/requirements.txt`
 
 # Configure the script
 
 Create a copy of the postdns.ini file and rename it postdns.local.ini to avoid tampering with the reference config (if no postdns.local.ini exists, the reference config will be used)
 
 Edit the config file and change
+
 - under the `DOMAIN` section the `hostname` field with your local domain
 - under the `RESOLVER` section the `resolver_ip` field with your resolver (default is 127.0.0.1)
     - to use multiple resolvers, seperate them with comma `,`
 - under the `RESOLVER` section the `resolver_port` field with the port your resolver listens (default is 53)
 
-Discussion:
+The script queries the destination domain for a specific SRV record, `_onion-mx._tcp.` and if it finds a `.onion` address in the reply it gives it back to postfix to be used by the `smtptor` service defined in `master.cf`. If no valid SRV record is found the mail is passed to `smtp` service. This gives us dynamic SRV lookups that lead to SMTP over onion addresses!
 
-The script queries the destination domain for a specific SRV record, '_onion-mx._tcp.' and if it finds a '.onion' address in the reply it gives it back to postfix to be used by the 'smtptor' service defined in master.cf. If no valid SRV record is found the mail is passed to 'smtp' service. This gives us dynamic SRV lookups that lead to SMTP over onion addresses!
 - To change the SRV record the scripts looks for, edit the config file mentioned above and change under the `DNS` section the `srv_record` field with the SRV record you have setup (default is `_onion-mx._tcp.`)
-- To change the service that will be used when a '.onion' address is found,  edit the config file mentioned above and change under the `REROUTE` section the `onion_transport` field with the service you want to be used (default is `smtptor`)
+- To change the service that will be used when a `.onion` address is found,  edit the config file mentioned above and change under the `REROUTE` section the `onion_transport` field with the service you want to be used (default is `smtptor`)
+
+
+## Static resolution option
+
+Static lookups are supported with two different ways:
+
+1. Through the [postdns script](postdns/postdns.py)
+    - In yaml format in the `sources` folder
+        - Project already contains [a yaml file](sources/map.yml) which has some predefined mappings
+    - Anything in the `sources` folder will be treated as a yaml file serving the static resolution (multiple files supported)
+    - To add your own mappings, you can create your own yaml file in the `sources` folder either manually or by running [the generation script you can find
+    in this repository](scripts/map2postfix-transport.rb)
+2. [Directly in the postfix level](#configure-postfix)
 
 # Configure postfix
 

--- a/config/postdns.ini
+++ b/config/postdns.ini
@@ -1,6 +1,7 @@
 [RESOLVER]
 resolver_ip:         127.0.0.1
 resolver_port:       53
+tcp:                 True
 
 [DOMAIN]
 hostname:            myself.net

--- a/postdns/libs.py
+++ b/postdns/libs.py
@@ -1,5 +1,7 @@
 import sys
 import os
+from collections import namedtuple
+from yaml import load
 try:
     import ConfigParser as configparser
 except ImportError:
@@ -42,3 +44,18 @@ def find_conffile(conf_path, prefix='', suffix=".ini"):
 
     raise Exception('No configuration file found in {0}'.format(conf_path))
 
+
+def yaml_loader(yaml_path):
+    if os.path.exists(yaml_path):
+        folder_structure = namedtuple('fst', ('dir', 'folders', 'files'))
+        structure = folder_structure(*tuple(os.walk(yaml_path))[0])
+        for filename in structure.files:
+            with open("{0}/{1}".format(yaml_path, filename), 'r') as f:
+                yield f
+
+
+def load_yamls(yaml_path):
+    yaml_mapping = dict()
+    for f in yaml_loader(yaml_path):
+        yaml_mapping.update(load(f))
+    return yaml_mapping

--- a/postdns/olookup.py
+++ b/postdns/olookup.py
@@ -1,0 +1,46 @@
+import dns.exception
+import dns.resolver
+import re
+
+
+class OnionServiceLookup(object):
+    def __init__(self, config):
+        self.config = config
+        self.resolver = dns.resolver.Resolver()
+        self.resolver.nameservers = self.config.get("RESOLVER",
+                                                    "resolver_ip").split(",")
+        self.resolver.port = int(self.config.get("RESOLVER", "resolver_port"))
+
+    @property
+    def srv_record(self):
+        return self.config.get("DNS", "srv_record")
+
+    @property
+    def use_tcp(self):
+        return self.config.get("RESOLVER", "tcp") == "True"
+
+    @staticmethod
+    def is_onion(response):
+        return re.search(r"onion\.$", response) is not None
+
+    def _craft_format_record(self, domain):
+        return "{0}{1}".format(self.srv_record, domain)
+
+    def _map_answers(self, answers):
+        return tuple(filter(self.is_onion, (str(x.target) for x in answers)))
+
+    @staticmethod
+    def _craft_output(answers):
+        if answers:
+            return tuple("{data}".format(data=str(x).rstrip('.'))
+                         for x in answers)
+        else:
+            return tuple("")
+
+    def lookup(self, domain):
+        try:
+            query = self.resolver.query(self._craft_format_record(domain),
+                                        "SRV", tcp=self.use_tcp)
+            return self._craft_output(self._map_answers(query))
+        except dns.exception.DNSException:
+            return tuple("")

--- a/postdns/postfixrerouter.py
+++ b/postdns/postfixrerouter.py
@@ -1,0 +1,48 @@
+from abc import abstractmethod, ABCMeta
+import libs
+
+
+class PostfixRerouter(object):
+    __metaclass__ = ABCMeta
+
+    def __init__(self, config):
+        self.config = config
+
+    @property
+    def reroute_service(self):
+        return self.config.get("REROUTE", "onion_transport")
+
+    @abstractmethod
+    def reroute(self, answers):
+        return tuple("200 {rservice}:[{ans}]".format(
+            rservice=self.reroute_service, ans=x) for x in answers)
+
+
+class LazyPostfixRerouter(PostfixRerouter):
+    def __init__(self, config, yaml_path):
+        super(LazyPostfixRerouter, self).__init__(config)
+        self.mappings_path = yaml_path
+        self.static_mappings = dict()
+
+    def _setup_static_mappings(self):
+        for (key, vals) in libs.load_yamls(self.mappings_path).items():
+            self.static_mappings.update({x: key for x in vals})
+
+    def _lazy(self, domain):
+        mapping = self.static_mappings.get(domain)
+        return tuple([mapping]) if mapping else tuple()
+
+    def reroute(self, domain):
+        if not self.static_mappings:
+            self._setup_static_mappings()
+        return super(LazyPostfixRerouter, self).reroute(self._lazy(domain))
+
+
+class OnionPostfixRerouter(PostfixRerouter):
+    def __init__(self, config, onion_resolver):
+        super(OnionPostfixRerouter, self).__init__(config)
+        self.onion_resolver = onion_resolver
+
+    def reroute(self, domain):
+        return super(OnionPostfixRerouter, self).reroute(
+            self.onion_resolver.lookup(domain))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+dnspython
+PyYAML


### PR DESCRIPTION
Add requirements.txt
PostDNS class for configuration & service mapping the lookup results
OnionserviceLookup class to take care of the actual resolution and 
service mapping with tcp / udp support
Add OnionPostfixRerouter and LazyPostfixRerouter
Use LazyPostfixRerouter to return a value from the yaml
before trying the OnionPostfixRerouter