### PR TITLE
Remove duplicate for espora.org.

### DIFF
--- a/sources/map.yml
+++ b/sources/map.yml
@@ -47,8 +47,6 @@
   - 'lelutin.ca'
 'wy6zk3pmcwiyhiao.onion':
   - 'riseup.net'
-'tyiw2fzn3uckv2my.onion':
-  - 'espora.org'
 'xpgylzydxykgdqyg.onion':
   - 'lists.riseup.net'
 'ysp4gfuhnmj6b4mb.onion':


### PR DESCRIPTION
This duplicate was added in commit d5f035d4.