### PR TITLE
Double quote to avoid re-splitting in smtp_tor

### DIFF
--- a/postfix.md
+++ b/postfix.md
@@ -47,7 +47,7 @@ In `smtp_tor`:
 
     #!/bin/sh
 
-    /usr/bin/torsocks -i /usr/lib/postfix/smtp $@
+    /usr/bin/torsocks -i /usr/lib/postfix/smtp "$@"
 
 Make it executable.
 


### PR DESCRIPTION
Double quote array expansions to avoid re-splitting elements

See https://github.com/koalaman/shellcheck/wiki/SC2068