### PR TITLE
in debian the smtp binary has a slightly different path

### DIFF
--- a/postfix.md
+++ b/postfix.md
@@ -49,6 +49,9 @@ In `smtp_tor`:
 
     /usr/bin/torsocks -i /usr/lib/postfix/smtp "$@"
 
+Note that in debian, the path to the `smtp` binary might need to be changed
+to `/usr/lib/postfix/sbin/smtp` in the script above.
+
 Make it executable.
 
     chmod +x $(postconf -h daemon_directory)/smtp_tor


### PR DESCRIPTION
When I was trying to set this up I blindly copied the contents of the smtp_tor script. I was then getting an error when postfix was calling out to it:

~~~
Nov  1 23:14:54 bahr postfix/master[34566]: warning: process /usr/lib/postfix/sbin/smtp_tor pid 41692 exit status 1
Nov  1 23:14:54 bahr postfix/master[34566]: warning: /usr/lib/postfix/sbin/smtp_tor: bad command startup -- throttling
~~~

The path to the `smtp` binary was wrong for a default debian install so torsocks couldn't do anything useful.