### PR TITLE
changed the address of onion service for my host

### DIFF
--- a/sources/map.yml
+++ b/sources/map.yml
@@ -46,7 +46,7 @@
   - 'sweetpepper.org'
 'tyiw2fzn3uckv2my.onion':
   - 'espora.org'
-'6powteszncqwdutlfs57n33i2zqt6jqc2wdcneaihtvrzaps3q3qtwyd.onion':
+'jgecrfpk22iz7zihnybhmmxu6nwy546moeuiy33lrepbg5rdchbhu4qd.onion':
   - 'lelutin.ca'
 'aj3nsqqcksrrc5cye5etjsoewz6jrygpekzwoko3q6wyxjlb3dgasfid.onion':
   - 'riseup.net'


### PR DESCRIPTION
this source file is not completely up to date -- we still have a couple of onion service v2 addresses, but there might still be folks using it instead of auto-discovery (I've only just implemented auto-discovery this month on my personal server). I'll keep the address for my server up to date in case some ppl are still generating their transport maps out of it.