### PR TITLE
Fixes #23: Remove unusable v2 onion addresses from map file.

### DIFF
--- a/sources/map.yml
+++ b/sources/map.yml
@@ -18,34 +18,20 @@
 #
 # Rerun the scripts to generate the mappings for your MTA.
 ---
-'blackhost5xlrhev.onion':
 'blackhost7pws76u6vohksdahnm6adf7riukgcmahrwt43wv2drvyxid.onion':
   - 'blackhost.xyz'
-'4my2dd2okjr75aho.onion':
+'kz4bswvhrqufq7e3ntwtco7jwgrpwwmh5j5kvlbonogt7xoipzwfedyd.onion':
   - 'calyx.com'
   - 'calyxinstitute.org'
-'cssj56utefk3wxsv.onion':
-  - 'boum.org'
 'llqiiswupgezsco4ux47cco3bxsaihbss5c3piefv6bhvpgfofyk7kad.onion':
   - 'systemli.org'
 'abupq2yypwtojgupttylrbwnabmpmydsf4evb2onasmib2go23jyyhqd.onion':
   - 'koumbit.org'
 'asgsory2hji5qpkmgyig2nzquolu5qhsfhz2qaiixdfgivzxlhrahzyd.onion':
   - 'sindominio.net'
-'lloiryev7cvzszsn.onion':
-  - 'espiv.net'
 'xibrfarp4uiwgjrfwbefue6kwlglxxdnfkiebbxcenm4qgg6vcnweqid.onion':
   - 'mail36.net'
   - 'so36.net'
-'mssatgg2rwa4aytk.onion':
-  - 'anargeek.net'
-  - 'irq7.fr'
-  - 'pimienta.org'
-  - 'poivron.org'
-  - 'potager.org'
-  - 'sweetpepper.org'
-'tyiw2fzn3uckv2my.onion':
-  - 'espora.org'
 '6powteszncqwdutlfs57n33i2zqt6jqc2wdcneaihtvrzaps3q3qtwyd.onion':
   - 'lelutin.ca'
 'aj3nsqqcksrrc5cye5etjsoewz6jrygpekzwoko3q6wyxjlb3dgasfid.onion':
@@ -73,5 +59,3 @@
   - 'supernormal.net'
   - 'ungehorsam.ch'
   - 'untenlinks.ch'
-'zq36q5rfxd3cnvd5.onion':
-  - 'lists.espiv.net'


### PR DESCRIPTION
Tor v0.4.6, released in June 2021, removed all support for v2 onion addressing and lookups. The Tor network now only supports v3 addresses. Thus, this commit removed all of the unusable v2 addresses from the map file.

The following domains only had v2 addresses in the mapping file, and do not publish an onion-mx SRV record anymore, so they were completely removed:
 - anargeek.net
 - boum.org
 - espiv.net and lists.espiv.net
 - espora.org
 - irq7.fr
 - pimienta.org
 - poivron.org
 - potager.org
 - sweetpepper.org

The Calyx Institute's domains only had v2 addresses in the mapping file, but now publish v3 onion-mx records, so those got updated.

Fixes: #23 